### PR TITLE
Add a bug report template for the public

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
As we roll out GemBrow live, it will be important to collect bug reports directly from users.

The envisioned workflow for this:

![image](https://github.com/PavlidisLab/GemBrow/assets/1318477/25127197-6ed6-43c6-9c32-648ccca82f32)

The "Report on GitHub" would unroll the gory details and the ability to open an issue using the template proposed in this PR.

![image](https://github.com/PavlidisLab/GemBrow/assets/1318477/67ddf668-8aed-4be0-862a-e8e5af61bf6a)

