### PR TITLE
Dataset preview terms

### DIFF
--- a/src/components/AnnotationSelector.vue
+++ b/src/components/AnnotationSelector.vue
@@ -102,6 +102,7 @@ export default {
         return this.getNumberOfExpressionExperiments(b) - this.getNumberOfExpressionExperiments(a);
       };
       return this.annotations
+      
         .map(a => {
           let that = this;
 
@@ -211,7 +212,8 @@ export default {
       return newVal
         // exclude annotations from selected categories
         .filter(a => !sc.has(a.split(SEPARATOR, 2)[0]))
-        .map(a => this.annotationById[a]);
+        .map(a => this.annotationById[a])
+        .filter(a => a);
     },
     /**
      * Selected categories.
@@ -231,6 +233,7 @@ export default {
   },
   watch: {
     value(newVal){
+      // make sure that newVal is an option
       this.selectedValues = newVal.map(term => this.getId(term));
     },
     selectedValues(newVal, oldVal) {

--- a/src/components/AnnotationSelector.vue
+++ b/src/components/AnnotationSelector.vue
@@ -30,6 +30,8 @@
                 <div v-if="!item.isCategory || debug" class="text-right">
                     {{ formatNumber(item.numberOfExpressionExperiments) }}<br>
                 </div>
+                <div v-if="item.isCategory && !debug && getNumberCategorySelections(item) > 0" class="text-right" style="font-size: 14px; color: grey;"> {{ getNumberCategorySelections(item) }} selected <br>
+                </div>
             </template>
         </v-treeview>
         <p v-show="annotations.length === 0 && !loading">
@@ -195,6 +197,11 @@ export default {
           return source.getExternalUrl(uri);
         }
       }
+    },
+    getNumberCategorySelections(item) {
+      let classUri = item.classUri;
+      let selectedValuesClassUris = this.selectedValues.map(Values => Values.split('|')[0]);
+      return selectedValuesClassUris.filter(value => value.includes(classUri)).length;
     },
     /**
      * Selected annotations, grouped by category and excluding selected categories.

--- a/src/components/AnnotationSelector.vue
+++ b/src/components/AnnotationSelector.vue
@@ -223,6 +223,9 @@ export default {
     }
   },
   watch: {
+    value(newVal){
+      this.selectedValues = newVal.map(term => this.getId(term));
+    },
     selectedValues(newVal, oldVal) {
       let sc = this.computeSelectedCategories(newVal);
       let sa = this.computeSelectedAnnotations(newVal, sc);

--- a/src/components/AnnotationSelector.vue
+++ b/src/components/AnnotationSelector.vue
@@ -230,11 +230,17 @@ export default {
      */
     computeSelectedAnnotations(newVal, selectedCategories) {
       let sc = new Set(selectedCategories.map(sc => getCategoryId(sc)));
-      return newVal
+      let selectedAnnotations = newVal
         // exclude annotations from selected categories
         .filter(a => !sc.has(a.split(SEPARATOR, 2)[0]))
-        .map(a => this.annotationById[a])
-        .filter(a => a);
+        .map(a => this.annotationById[a]);
+        selectedAnnotations.forEach(a => {
+          if (!a) {
+            console.warn('Term is not selectable');
+          }
+        });
+
+        return selectedAnnotations.filter(a => a)
     },
     /**
      * Selected categories.

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,9 +1,8 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <v-chip v-for="term in includedTerms" :key="term.termUri">{{ term.termName }}</v-chip> 
+        <v-chip v-for="term in includedTerms" :key="term.termUri" @click="handleChipClick(term.termName)" small>{{ term.termName }} </v-chip> 
         <!--* 
-          * Add the termName and parentName values as chips
           * Color code the chips to correspond to categories (which categories?)
           * Add termName/name of chip to search query on click
         -->
@@ -13,7 +12,7 @@
 
 <script>
 import { highlight } from "@/search-utils";
-import { marked, axiosInst, baseUrl, excludedTerms } from "@/config/gemma";
+import { marked, axiosInst, baseUrl, excludedTerms, excludedCategories } from "@/config/gemma";
 
 export default {
   name: "DatasetPreview",
@@ -37,7 +36,6 @@ export default {
   methods: {
     getTerms() {
     const dataset = this.dataset.id
-    console.log('dataset', dataset)
     return axiosInst.request({
       method: 'GET',
         url: baseUrl + `/rest/v2/datasets/annotations`,
@@ -46,24 +44,21 @@ export default {
         }
       })
       .then(response => {
-        console.log('datasets/annotations endpoint data', response.data);
         return response.data.data;
       }).catch(error => {
-        console.error('Failed to get datasets/annotations endpoint data', error);
       });
-   }
+   },
+   handleChipClick(termName) {
+    this.$emit('chip-clicked', termName); // Emit the termUri to the parent or other components
+    }
   },
   created() {
     /** 
-     * Dispatch the API request when the user opens the dataset preview window 
-     * Query the dataset/annotation endpoint (getTerms())
-     * store termName for selected experiment
-     * keep only terms not on exclusion list
      * store the Name for any of the parent terms that are not selected as a chip below the title
     */ 
    this.getTerms().then(terms => {
     this.terms = terms;
-    this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri));
+    this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri));
    });
   }
 };

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <v-chip v-for="term in includedTerms" :key="term.termUri" @click="handleChipClick(term.termName)" small>{{ term.termName }} </v-chip> 
+        <v-chip v-for="term in includedTerms" :key="term.termUri" @click="handleChipClick(term.termName)" small :color="getChipColor(term.objectClass)">{{ term.termName }} </v-chip> 
         <!--* 
           * Color code the chips to correspond to categories (which categories?)
           * Add termName/name of chip to search query on click
@@ -31,6 +31,13 @@ export default {
         return marked.parseInline(highlight(this.dataset.description, this.dataset.searchResult.highlights.description));
       }
       return marked.parseInline(this.dataset.description);
+    },
+    chipColorMap() {
+      return {
+        FactorValue: 'yellow',
+        ExperimentTag: 'green',
+        BioMaterial: 'blue'
+      };
     }
   },
   methods: {
@@ -38,7 +45,7 @@ export default {
     const dataset = this.dataset.id
     return axiosInst.request({
       method: 'GET',
-        url: baseUrl + `/rest/v2/datasets/annotations`,
+        url: baseUrl + `/rest/v2/datasets/${dataset}/annotations`,
         params: {
           filter: `id = ${dataset}`
         }
@@ -50,15 +57,18 @@ export default {
    },
    handleChipClick(termName) {
     this.$emit('chip-clicked', termName); // Emit the termUri to the parent or other components
+    },
+    getChipColor(objectClass) {
+      return this.chipColorMap[objectClass] || 'orange'
     }
   },
   created() {
     /** 
      * store the Name for any of the parent terms that are not selected as a chip below the title
     */ 
-   this.getTerms().then(terms => {
-    this.terms = terms;
-    this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri));
+    this.getTerms().then(terms => {
+      this.terms = terms;
+      this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri));
    });
   }
 };

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,18 +1,29 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <span v-html="this.description"></span>
+        <v-chip v-for="term in terms" :key="term.termUri">{{ term.termName }}</v-chip> 
+        <!--* 
+          * Add the termName and parentName values as chips
+          * Color code the chips to correspond to categories (which categories?)
+          * Add termName/name of chip to search query on click
+        -->
+        <div v-html="this.description"></div>
     </div>
 </template>
 
 <script>
 import { highlight } from "@/search-utils";
-import { marked } from "@/config/gemma";
+import { marked, axiosInst, baseUrl } from "@/config/gemma";
 
 export default {
   name: "DatasetPreview",
   props: {
-    dataset: Object
+    dataset: Object    
+  },
+  data() {
+    return {
+      terms: []
+    }
   },
   computed: {
     description() {
@@ -21,6 +32,37 @@ export default {
       }
       return marked.parseInline(this.dataset.description);
     }
+  },
+  methods: {
+    getTerms() {
+    const dataset = this.dataset.id
+    console.log('dataset', dataset)
+    return axiosInst.request({
+      method: 'GET',
+        url: baseUrl + `/rest/v2/datasets/annotations`,
+        params: {
+          filter: `id = ${dataset}`
+        }
+      })
+      .then(response => {
+        console.log('datasets/annotations endpoint data', response.data);
+        return response.data.data;
+      }).catch(error => {
+        console.error('Failed to get datasets/annotations endpoint data', error);
+      });
+   }
+  },
+  created() {
+    /** 
+     * Dispatch the API request when the user opens the dataset preview window 
+     * Query the dataset/annotation endpoint (getTerms())
+     * store termName for selected experiment
+     * store the Name for any of the parent terms that are not selected as a chip below the title
+    */ 
+   console.log('this.dataset', this.dataset)
+   this.getTerms().then(terms => {
+    this.terms = terms;
+   });
   }
 };
 </script>

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -60,16 +60,7 @@ export default {
         BioMaterial: 'blue'
       };
     },
-/*    availableAnnotationsIncludedTerms() {
-    console.log('it is happening')
-      return this.includedTerms.filter(term => {
-        // Check if the termUri is included in any of the children arrays
-        return this.availableAnnotations.some(annotation =>
-          annotation.children.some(child => child.termUri === term.termUri)
-        );
-      });
-    },*/
-     availableAnnotationsIncludedTerms() {
+    availableAnnotationsIncludedTerms() {
       const availableAnnotationIds = new Set();
         this.availableAnnotations.forEach(annotation => {
           annotation.children.forEach(child => {

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -26,6 +26,13 @@
 import { highlight } from "@/search-utils";
 import { marked, axiosInst, baseUrl, excludedTerms, excludedCategories } from "@/config/gemma";
 import { mapState } from "vuex";
+import { getCategoryId, getTermId } from "@/utils";
+
+/**
+ * Separator used to constructing keys of nested elements in the tree view.
+ * @type {string}
+ */
+ const SEPARATOR = "|";
 
 export default {
   name: "DatasetPreview",
@@ -53,13 +60,28 @@ export default {
         BioMaterial: 'blue'
       };
     },
-    availableAnnotationsIncludedTerms() {
+/*    availableAnnotationsIncludedTerms() {
+    console.log('it is happening')
       return this.includedTerms.filter(term => {
         // Check if the termUri is included in any of the children arrays
         return this.availableAnnotations.some(annotation =>
           annotation.children.some(child => child.termUri === term.termUri)
         );
       });
+    },*/
+     availableAnnotationsIncludedTerms() {
+      const availableAnnotationIds = new Set();
+        this.availableAnnotations.forEach(annotation => {
+          annotation.children.forEach(child => {
+            availableAnnotationIds.add(this.getId(child));
+          });
+        });
+
+      const filteredIncludedTerms = this.includedTerms.filter(term => {
+        return availableAnnotationIds.has(this.getId(term));
+      });
+
+      return filteredIncludedTerms;
     },
     ...mapState({
       debug: state => state.debug
@@ -77,6 +99,9 @@ export default {
         }).catch(error => {
           this.setLastError
       });
+    },
+    getId(term) {
+      return getCategoryId(term) + SEPARATOR + getTermId(term);
     },
     handleChipClick(term) {
       this.$emit('chip-clicked', term); 

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -73,6 +73,7 @@ export default {
         if (!excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri) && !seenTermUris.has(term.termUri)) {
           seenTermUris.add(term.termUri);
           return true;
+        } else {
         return false; 
         }
       });

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <v-chip v-for="term in includedTerms" 
+        <v-chip v-for="term in availableAnnotationsIncludedTerms" 
                 :key="term.termUri" @click="handleChipClick(term)" 
                 small :color="getChipColor(term.objectClass)">
                 {{ term.termName }} 
@@ -18,7 +18,8 @@ import { marked, axiosInst, baseUrl, excludedTerms, excludedCategories } from "@
 export default {
   name: "DatasetPreview",
   props: {
-    dataset: Object    
+    dataset: Object,
+    availableAnnotations: Array    
   },
   data() {
     return {
@@ -39,6 +40,14 @@ export default {
         ExperimentTag: 'green',
         BioMaterial: 'blue'
       };
+    },
+    availableAnnotationsIncludedTerms() {
+      return this.includedTerms.filter(term => {
+        // Check if the termUri is included in any of the children arrays
+        return this.availableAnnotations.some(annotation =>
+          annotation.children.some(child => child.termUri === term.termUri)
+        );
+      });
     }
   },
   methods: {
@@ -54,11 +63,11 @@ export default {
           this.setLastError
       });
     },
-    handleChipClick(termName) {
-      this.$emit('chip-clicked', termName); // Emit the termUri to the parent or other components
-      },
-      getChipColor(objectClass) {
-        return this.chipColorMap[objectClass] || 'orange'
+    handleChipClick(term) {
+      this.$emit('chip-clicked', term); 
+    },
+    getChipColor(objectClass) {
+      return this.chipColorMap[objectClass] || 'orange'
     }
   },
   created() {

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -51,6 +51,7 @@ export default {
         .then(response => {
           return response.data.data;
         }).catch(error => {
+          this.setLastError
       });
     },
     handleChipClick(termName) {

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <v-chip v-for="term in terms" :key="term.termUri">{{ term.termName }}</v-chip> 
+        <v-chip v-for="term in includedTerms" :key="term.termUri">{{ term.termName }}</v-chip> 
         <!--* 
           * Add the termName and parentName values as chips
           * Color code the chips to correspond to categories (which categories?)
@@ -13,7 +13,7 @@
 
 <script>
 import { highlight } from "@/search-utils";
-import { marked, axiosInst, baseUrl } from "@/config/gemma";
+import { marked, axiosInst, baseUrl, excludedTerms } from "@/config/gemma";
 
 export default {
   name: "DatasetPreview",
@@ -22,7 +22,8 @@ export default {
   },
   data() {
     return {
-      terms: []
+      terms: [],
+      includedTerms: []
     }
   },
   computed: {
@@ -57,11 +58,12 @@ export default {
      * Dispatch the API request when the user opens the dataset preview window 
      * Query the dataset/annotation endpoint (getTerms())
      * store termName for selected experiment
+     * keep only terms not on exclusion list
      * store the Name for any of the parent terms that are not selected as a chip below the title
     */ 
-   console.log('this.dataset', this.dataset)
    this.getTerms().then(terms => {
     this.terms = terms;
+    this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri));
    });
   }
 };

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -42,30 +42,27 @@ export default {
   },
   methods: {
     getTerms() {
-    const dataset = this.dataset.id
-    return axiosInst.request({
-      method: 'GET',
-        url: baseUrl + `/rest/v2/datasets/${dataset}/annotations`,
-        params: {
-          filter: `id = ${dataset}`
-        }
-      })
-      .then(response => {
-        return response.data.data;
-      }).catch(error => {
+      const dataset = this.dataset.id
+      return axiosInst.request({
+        method: 'GET',
+          url: baseUrl + `/rest/v2/datasets/${dataset}/annotations`,
+          params: {
+            filter: `id = ${dataset}`
+          }
+        })
+        .then(response => {
+          return response.data.data;
+        }).catch(error => {
       });
-   },
-   handleChipClick(termName) {
-    this.$emit('chip-clicked', termName); // Emit the termUri to the parent or other components
     },
-    getChipColor(objectClass) {
-      return this.chipColorMap[objectClass] || 'orange'
+    handleChipClick(termName) {
+      this.$emit('chip-clicked', termName); // Emit the termUri to the parent or other components
+      },
+      getChipColor(objectClass) {
+        return this.chipColorMap[objectClass] || 'orange'
     }
   },
   created() {
-    /** 
-     * store the Name for any of the parent terms that are not selected as a chip below the title
-    */ 
     this.getTerms().then(terms => {
       this.terms = terms;
       const seenTermUris = new Set(); // Log the URIs of objects in the terms array to omit duplicates and prevent duplicate URIs causing errors
@@ -74,7 +71,7 @@ export default {
           seenTermUris.add(term.termUri);
           return true;
         } else {
-        return false; 
+          return false; 
         }
       });
     });

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,12 +1,23 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
+        <div v-if="!debug" >
         <v-chip v-for="term in availableAnnotationsIncludedTerms" 
                 :key="term.termUri" @click="handleChipClick(term)" 
                 small :color="getChipColor(term.objectClass)">
                 {{ term.termName }} 
                 <v-icon right>mdi-plus</v-icon>
           </v-chip> 
+        </div>
+        <div v-else >
+        <v-chip v-for="term in includedTerms" 
+                :key="term.termUri" @click="handleChipClick(term)" 
+                small :color="getChipColor(term.objectClass)" :outlined="!availableAnnotationsIncludedTerms.includes(term)">
+                {{ term.termName }} 
+                <v-icon right>mdi-plus</v-icon>
+          </v-chip> 
+        </div>
+
         <div v-html="this.description"></div>
     </div>
 </template>
@@ -14,6 +25,7 @@
 <script>
 import { highlight } from "@/search-utils";
 import { marked, axiosInst, baseUrl, excludedTerms, excludedCategories } from "@/config/gemma";
+import { mapState } from "vuex";
 
 export default {
   name: "DatasetPreview",
@@ -48,7 +60,10 @@ export default {
           annotation.children.some(child => child.termUri === term.termUri)
         );
       });
-    }
+    },
+    ...mapState({
+      debug: state => state.debug
+    })
   },
   methods: {
     getTerms() {

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -2,9 +2,10 @@
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
         <v-chip v-for="term in includedTerms" 
-                :key="term.termUri" @click="handleChipClick(term.termName)" 
+                :key="term.termUri" @click="handleChipClick(term)" 
                 small :color="getChipColor(term.objectClass)">
                 {{ term.termName }} 
+                <v-icon right>mdi-plus</v-icon>
           </v-chip> 
         <div v-html="this.description"></div>
     </div>
@@ -45,10 +46,7 @@ export default {
       const dataset = this.dataset.id
       return axiosInst.request({
         method: 'GET',
-          url: baseUrl + `/rest/v2/datasets/${dataset}/annotations`,
-          params: {
-            filter: `id = ${dataset}`
-          }
+          url: baseUrl + `/rest/v2/datasets/${dataset}/annotations`
         })
         .then(response => {
           return response.data.data;

--- a/src/components/DatasetPreview.vue
+++ b/src/components/DatasetPreview.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="py-3">
         <h3>{{ dataset.name }}</h3>
-        <v-chip v-for="term in includedTerms" :key="term.termUri" @click="handleChipClick(term.termName)" small :color="getChipColor(term.objectClass)">{{ term.termName }} </v-chip> 
-        <!--* 
-          * Color code the chips to correspond to categories (which categories?)
-          * Add termName/name of chip to search query on click
-        -->
+        <v-chip v-for="term in includedTerms" 
+                :key="term.termUri" @click="handleChipClick(term.termName)" 
+                small :color="getChipColor(term.objectClass)">
+                {{ term.termName }} 
+          </v-chip> 
         <div v-html="this.description"></div>
     </div>
 </template>
@@ -68,8 +68,15 @@ export default {
     */ 
     this.getTerms().then(terms => {
       this.terms = terms;
-      this.includedTerms = terms.filter(term => !excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri));
-   });
+      const seenTermUris = new Set(); // Log the URIs of objects in the terms array to omit duplicates and prevent duplicate URIs causing errors
+      this.includedTerms = terms.filter(term => {
+        if (!excludedTerms.includes(term.termUri) && !excludedCategories.includes(term.classUri) && !seenTermUris.has(term.termUri)) {
+          seenTermUris.add(term.termUri);
+          return true;
+        return false; 
+        }
+      });
+    });
   }
 };
 </script>

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -702,7 +702,6 @@ export default {
     },
     ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"]),
     handleChipClicked(previewTerm) {
-      console.log(previewTerm);
      this.searchSettings.annotations.push({
         classUri: previewTerm.classUri, 
         className: previewTerm.className,

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -701,12 +701,9 @@ export default {
         .join(" ");
     },
     ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"]),
-    handleChipClicked(termName) {
-      termName = termName.replace(/[\(\)\[\]]/g, "")
-      if (this.searchSettings.query !== null && this.searchSettings.query !== '') {
-        this.searchSettings.query += `, ${termName}`
-      } else { this.searchSettings.query = termName
-        }
+    handleChipClicked(previewTerm) {
+     console.log('previewTerm', previewTerm)
+     this.searchSettings.annotations.push(previewTerm)
     }
   },
   created() {

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -66,7 +66,7 @@
                 </template>
                 <template v-slot:expanded-item="{item}">
                     <td :colspan="headers.length + 1">
-                        <DatasetPreview :dataset="item"></DatasetPreview>
+                        <DatasetPreview :dataset="item" @chip-clicked="handleChipClicked"></DatasetPreview>
                     </td>
                 </template>
                 <template v-slot:footer.prepend>
@@ -700,7 +700,13 @@ export default {
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join(" ");
     },
-    ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"])
+    ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"]),
+    handleChipClicked(termName) {
+      if (this.searchSettings.query !== null) {
+        this.searchSettings.query += ' ';
+      }
+      this.searchSettings.query += termName;
+    }
   },
   created() {
     return Promise.all([compressArg(excludedCategories.join(",")), compressArg(excludedTerms.join(","))])

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -702,10 +702,11 @@ export default {
     },
     ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"]),
     handleChipClicked(termName) {
-      if (this.searchSettings.query !== null) {
-        this.searchSettings.query += ' ';
-      }
-      this.searchSettings.query += termName;
+      termName = termName.replace(/[\(\)\[\]]/g, "")
+      if (this.searchSettings.query !== null && this.searchSettings.query !== '') {
+        this.searchSettings.query += `, ${termName}`
+      } else { this.searchSettings.query = termName
+        }
     }
   },
   created() {

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -453,6 +453,7 @@ export default {
         }
       }
       if (this.searchSettings.annotations.length > 0) {
+        console.log(this.searchSettings.annotations);
         const annotationGroups = this.searchSettings.annotations.reduce((acc, annotation) => {
           let { classUri, className, termName } = annotation;
           if (className) {
@@ -702,8 +703,12 @@ export default {
     },
     ...mapMutations(["setTitle", "setFilterSummary", "setFilterDescription"]),
     handleChipClicked(previewTerm) {
-     console.log('previewTerm', previewTerm)
-     this.searchSettings.annotations.push(previewTerm)
+      console.log(previewTerm);
+     this.searchSettings.annotations.push({
+        classUri: previewTerm.classUri, 
+        className: previewTerm.className,
+        termUri: previewTerm.termUri, 
+        termName: previewTerm.termName})
     }
   },
   created() {

--- a/src/views/Browser.vue
+++ b/src/views/Browser.vue
@@ -66,7 +66,7 @@
                 </template>
                 <template v-slot:expanded-item="{item}">
                     <td :colspan="headers.length + 1">
-                        <DatasetPreview :dataset="item" @chip-clicked="handleChipClicked"></DatasetPreview>
+                        <DatasetPreview :dataset="item" :availableAnnotations="datasetsAnnotations" @chip-clicked="handleChipClicked"></DatasetPreview>
                     </td>
                 </template>
                 <template v-slot:footer.prepend>
@@ -453,7 +453,6 @@ export default {
         }
       }
       if (this.searchSettings.annotations.length > 0) {
-        console.log(this.searchSettings.annotations);
         const annotationGroups = this.searchSettings.annotations.reduce((acc, annotation) => {
           let { classUri, className, termName } = annotation;
           if (className) {


### PR DESCRIPTION
This does not include the parent terms as tags. I switched back to the datasets/{dataset}/annotations API endpoint so that I could get the objectClass to color-code the chips. I used FactorValue, ExperimentTag, and BioMaterial with the same colors as Gemma (yellow, green, blue respectively). I left orange for anything else, but I'm not sure if any other objectClasses exist.